### PR TITLE
Putting textarea in a more developper-friendly way

### DIFF
--- a/public/css/default.css
+++ b/public/css/default.css
@@ -9,10 +9,15 @@ body {
     text-decoration: none !important;
 }
 textarea {
-	margin-top: 10px;
+    margin-top: 10px;
+    white-space: pre-wrap;
+    font-family: monospace;
+    tab-size: 4;
+    /* Used only for Firefox which does not apply tab-size */
+    -moz-tab-size: 4;
 }
 #form-content .pull-right {
-	margin-bottom: 10px;
+    margin-bottom: 10px;
     margin-top: -5px;
 }
 #context_queries {


### PR DESCRIPTION
- Textarea is set in monospace font (should work with all browser).
- Tabsize is set to 4 as defined in mysqlworkbench.
  - Works with Firefox, Chrome, Safari, Opera,
  - Does not work with Internet Explorer, Android, iOS.